### PR TITLE
Fix lint workflow permissions and repo housekeeping

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rblaine95
+* @didx-xyz/team-sre

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ jobs:
     name: Broken Markdown links
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -27,6 +30,12 @@ jobs:
   super-lint:
     name: Super Linter
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      statuses: write
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,11 +10,11 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '35 8 * * 2'
+    - cron: "35 8 * * 2"
   push:
-    branches: [ "master" ]
+    branches: [master]
   pull_request:
-    branches: [ "master" ]
+    branches: [master]
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,23 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  "ensure_final_newline_on_save": true,
+  "remove_trailing_whitespace_on_save": true,
+  "wrap_guides": [80, 120],
+  "lsp": {
+    "markdownlint": {
+      "settings": {
+        "MD013": {
+          "line_length": 120,
+          "code_blocks": false,
+          "tables": false,
+        },
+        "MD024": {
+          "siblings_only": true,
+        },
+      },
+    },
+  },
+}

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
@@ -79,7 +79,7 @@ We welcome contributions to improve these workflows! Please follow these steps:
 ## Related Projects
 
 - [DIDx ACA-Py Cloud](https://github.com/didx-xyz/acapy-cloud): Cloud based deployment for Self-Sovereign Identity (SSI)
-applications
+  applications
 
 ## About DIDx
 

--- a/connect-eks/README.md
+++ b/connect-eks/README.md
@@ -23,16 +23,16 @@ This is particularly useful for CI/CD workflows that need to interact with EKS c
 
 ## Inputs
 
-| Input | Description | Required | Default |
-| ----- | ----------- | -------- | ------- |
-| `aws-region` | The AWS region where the EKS cluster is located | Yes | N/A |
-| `aws-role-arn` | The ARN of the AWS role to assume | Yes | N/A |
-| `aws-role-session-name` | The name of the AWS role session | Yes | N/A |
-| `cluster-name` | The name of the EKS cluster | Yes | N/A |
-| `tailscale-authkey` | The Tailscale auth key | No | `''` |
-| `tailscale-oauth-client-id` | The Tailscale OAuth client ID | No | `''` |
-| `tailscale-oauth-secret` | The Tailscale OAuth client secret | No | `''` |
-| `tailscale-tags` | The Tailscale tags to use | No | `''` |
+| Input                       | Description                                     | Required | Default |
+| --------------------------- | ----------------------------------------------- | -------- | ------- |
+| `aws-region`                | The AWS region where the EKS cluster is located | Yes      | N/A     |
+| `aws-role-arn`              | The ARN of the AWS role to assume               | Yes      | N/A     |
+| `aws-role-session-name`     | The name of the AWS role session                | Yes      | N/A     |
+| `cluster-name`              | The name of the EKS cluster                     | Yes      | N/A     |
+| `tailscale-authkey`         | The Tailscale auth key                          | No       | `''`    |
+| `tailscale-oauth-client-id` | The Tailscale OAuth client ID                   | No       | `''`    |
+| `tailscale-oauth-secret`    | The Tailscale OAuth client secret               | No       | `''`    |
+| `tailscale-tags`            | The Tailscale tags to use                       | No       | `''`    |
 
 **Note**: You must provide either a `tailscale-authkey` OR both
 `tailscale-oauth-client-id` and `tailscale-oauth-secret` for Tailscale
@@ -86,13 +86,13 @@ jobs:
 This action performs the following steps:
 
 1. **Connect to Tailscale**: Establishes a VPN connection using Tailscale to securely access private networks where your
-EKS cluster may be located.
+   EKS cluster may be located.
 
 2. **Configure AWS Credentials**: Uses the AWS Actions credentials provider to assume the specified IAM role, which
-should have permissions to interact with the EKS cluster.
+   should have permissions to interact with the EKS cluster.
 
 3. **Update Kubeconfig**: Runs `aws eks update-kubeconfig` to configure kubectl with the necessary credentials and
-endpoint information for your EKS cluster.
+   endpoint information for your EKS cluster.
 
 After these steps are completed, subsequent steps in your workflow can use `kubectl` to interact with your EKS cluster.
 

--- a/connect-eks/action.yml
+++ b/connect-eks/action.yml
@@ -18,19 +18,19 @@ inputs:
   tailscale-authkey:
     description: The Tailscale auth key
     required: false
-    default: ''
+    default: ""
   tailscale-oauth-client-id:
     description: The Tailscale OAuth client ID
     required: false
-    default: ''
+    default: ""
   tailscale-oauth-secret:
     description: The Tailscale OAuth client secret
     required: false
-    default: ''
+    default: ""
   tailscale-tags:
     description: The Tailscale tags to use
     required: false
-    default: ''
+    default: ""
 
 runs:
   using: composite


### PR DESCRIPTION
## Why

The `Lint` workflow's `super-lint` job emitted `403` errors when posting results (visible on the recent Dependabot run):

- `POST /repos/didx-xyz/workflows/statuses/<sha>` -> "Failed to create GitHub Commit Status"
- `POST /repos/didx-xyz/workflows/issues/<n>/comments` -> "Failed to create GitHub issue comment"

Root cause: the job declared only `contents: read`, but Super Linter (`MULTI_STATUS: true` plus the default PR summary comment) needs write scopes.

## What

**Lint workflow permissions fix**

- `super-lint`: add `statuses: write` (commit statuses), `issues: write` + `pull-requests: write` (PR summary comment)
- `md-link-check`: scope to `contents: read`

These match Super Linter v8.7.0's documented permission set, and Dependabot honors the `permissions:` key (since 2021-10-11), so the 403s clear for Dependabot runs.

**Bundled housekeeping**

- `CODEOWNERS`: `@rblaine95` -> `@didx-xyz/team-sre`
- Formatting normalization (quoting, branch filters, indentation) across `scorecard.yml`, `connect-eks/action.yml`, `README.md`, and `connect-eks/README.md`
- Add `.zed/settings.json` with on-save formatting defaults

## Notes

- PRs from forks always receive a read-only token regardless of `permissions:`, so external-contributor PRs would still hit these 403s. Traffic here is Dependabot (same-repo), so granting scopes is the correct fix.

## Verification

- `lint.yml` parses cleanly; scopes confirmed structurally.
- End-to-end confirmation comes from this PR's own `Lint` run.